### PR TITLE
Don't crash when no points are returned from datadog.

### DIFF
--- a/lib/dogscaler/datadog.rb
+++ b/lib/dogscaler/datadog.rb
@@ -17,7 +17,7 @@ module Dogscaler
         exit 1
       end
       if res[1]['series'].empty?
-        logger.error "No results returned from query #{instance.query}"
+        logger.error "No results returned from query #{query}"
         exit 1
       end
       points = unzip(res)


### PR DESCRIPTION
Dogscaler crashes if ran with apply parameter datadog api returns no points for a configured query:
`in `process': undefined local variable or method `instance' for #<Dogscaler::Datadog:0x0000000271e8f8> (NameError)